### PR TITLE
Problems in Windows

### DIFF
--- a/split_settings/tools.py
+++ b/split_settings/tools.py
@@ -91,6 +91,7 @@ def include(*args, **kwargs):
             raise IOError('No such file: %s' % pattern)
 
         for included_file in files_to_include:
+            included_file = os.path.abspath(included_file)
             if included_file in included_files:
                 continue
 


### PR DESCRIPTION
Приветствую!!!

Пример такой:
```
include(
'base/middleware.py',
'base/debug_toolbar.py',
'base/*.py',
)
```

glob возвращает для первого и второго  параметра

> C:\...\project\settings\base/middleware.py
> C:\...\project\settings\base/debug_toolbar.py

glob возвращает для тех же файлов но с паттерном 'base/*.py'

> C:\...\project\settings\base\debug_toolbar.py
> C:\...\project\settings\base\middleware.py

В результате, MIDDLEWARE_CLASSES не содержит изменений из  debug_toolbar