### PR TITLE
Load globs in alhpebetical order to prevent undefined behavior

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,13 +86,21 @@ Tips and tricks
 
 You can use wildcards in file paths:
 
+.. code-block:: none
+
+    settings.d/
+    ├── 010-base.py
+    ├── 020-database.py
+    ├── 051-module-a.py
+    ├── 052-module-b.py
+    └── 090-secrets.py
+
+
 .. code:: python
 
-    include('components/my_app/*.py')
+    include('settings.d/*.py')
 
-Note that files are included in the order that ``glob`` returns them,
-probably in the same order as what ``ls -U`` would list them. The
-files are NOT in alphabetical order.
+**Note:** Files are included in alphabetical order.
 
 
 Do you want to contribute?

--- a/split_settings/tools.py
+++ b/split_settings/tools.py
@@ -86,7 +86,7 @@ def include(*args, **kwargs):
 
         # find files per pattern, raise an error if not found (unless file is
         # optional)
-        files_to_include = glob.glob(pattern)
+        files_to_include = sorted(glob.glob(pattern))
         if not files_to_include and not isinstance(conf_file, _Optional):
             raise IOError('No such file: {}'.format(pattern))
 

--- a/tests/settings/sequential.d/010-first.py
+++ b/tests/settings/sequential.d/010-first.py
@@ -1,0 +1,2 @@
+
+EXAMPLE_KEY = ['First']

--- a/tests/settings/sequential.d/020-second.py
+++ b/tests/settings/sequential.d/020-second.py
@@ -1,0 +1,2 @@
+
+EXAMPLE_KEY.extend(['Second'])  # noqa: F821

--- a/tests/settings/sequential.d/040-third.py
+++ b/tests/settings/sequential.d/040-third.py
@@ -1,0 +1,1 @@
+EXAMPLE_KEY.append('Third')  # noqa: F821

--- a/tests/settings/sequential.d/300-fourth.py
+++ b/tests/settings/sequential.d/300-fourth.py
@@ -1,0 +1,2 @@
+
+EXAMPLE_KEY.append('Fourth')  # noqa: F821

--- a/tests/test_sequential_import.py
+++ b/tests/test_sequential_import.py
@@ -1,0 +1,9 @@
+import split_settings.tools
+
+
+def test_sequential_glob(scope):
+    """
+    This test covers sequential glob imports
+    """
+    split_settings.tools.include('settings/sequential.d/*', scope=scope)
+    assert scope['EXAMPLE_KEY'] == ['First', 'Second', 'Third', 'Fourth']


### PR DESCRIPTION
Previously files were not sorted at all (using the order at which entries appear in the filesystem). With this approach every file needs to be capable of being loaded in any order- something I woudln't expect users to test for. Sorting files by name-order allows for index config files like 010-base.py and 030-secrets.py to load procedurally and deterministically, and reduces complexity when in use. 