### PR TITLE
Use unique values for autoreload dummy modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ TESTS_REQUIRE = [
     'flake8-comprehensions',
     'flake8-blind-except',
     'pep8-naming',
-    'flake8',  # fixes dependency resolution
+    'flake8==3.6.0',  # fixes dependency resolution
     'pytest-flake8',
 
     # This line should be the last one:

--- a/split_settings/tools.py
+++ b/split_settings/tools.py
@@ -99,8 +99,9 @@ def include(*args, **kwargs):
 
             # add dummy modules to sys.modules to make runserver autoreload
             # work with settings components
+            rel_path = os.path.relpath(included_file)
             module_name = '_split_settings.{}'.format(
-                conf_file[:conf_file.rfind('.')].replace('/', '.'),
+                rel_path[:rel_path.rfind('.')].replace('/', '.'),
             )
 
             module = types.ModuleType(str(module_name))


### PR DESCRIPTION
When using including files using patterns (globs), dummy module names do not include the individual config files themselves, but only the pattern defined specified (e.x. `_split_settings.core.*`). This ends up getting clobbered by the `gen_filenames` function in Django autoreload thereby only enabling autoreload functionality on the final file discovered by the pattern:

Example:
```
settings/
  __init__.py
  core/
    stuff.py
    things.py
```
Only modifications to `things.py` would trigger an autoreload, while those made to `stuff.py` would not.

This commit increased uniqueness of the dummy module names but including the relative path to the config file discovered. So now instead of one module with the name `_split_settings.core.*` referencing `settings/core/things.py`, we bypass the clobbering and end up with two dummy modules:
- `_split_settings.settings.core.stuff`: `settings/core/stuff.py`
- `_split_settings.settings.core.things`: `settings/core/things.py`

**EDIT: Also pin Flake8 version at 3.6.0**